### PR TITLE
Update travis configuration to use sudo builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,16 @@
-language: Java
+sudo: required
 
-jdk:
-  - oraclejdk8
-  - oraclejdk7
-  - openjdk7
+services:
+  - docker
+
+install:
+  - sudo service docker stop
+  - sudo curl https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 -o /usr/bin/docker
+  - sudo chmod +x /usr/bin/docker
+  - sudo service docker start
+
+before_script:
+  - docker version
+
+script:
+  - ./gradlew check

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -29,7 +29,7 @@
             <property name="allowNonPrintableEscapes" value="true"/>
         </module>
         <module name="LineLength">
-            <property name="max" value="100"/>
+            <property name="max" value="120"/>
             <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
         </module>
         <module name="AvoidStarImport"/>
@@ -41,7 +41,7 @@
         </module>
         <module name="NeedBraces"/>
         <module name="LeftCurly">
-            <property name="maxLineLength" value="100"/>
+            <property name="maxLineLength" value="120"/>
         </module>
         <module name="RightCurly"/>
         <module name="RightCurly">
@@ -143,12 +143,12 @@
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>
-        <module name="CustomImportOrder">
-            <property name="specialImportsRegExp" value="com.google"/>
-            <property name="sortImportsInGroupAlphabetically" value="true"/>
-            <property name="customImportOrderRules"
-                      value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>
-        </module>
+        <!--<module name="CustomImportOrder">-->
+            <!--<property name="specialImportsRegExp" value="com.google"/>-->
+            <!--<property name="sortImportsInGroupAlphabetically" value="true"/>-->
+            <!--<property name="customImportOrderRules"-->
+                      <!--value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>-->
+        <!--</module>-->
         <module name="MethodParamPad"/>
         <module name="OperatorWrap">
             <property name="option" value="NL"/>


### PR DESCRIPTION
This is to be able to build it against a specific version of docker and
do more advanced stuff (like running different daemon version, etc..).

And… remove a checkstyle thingy.